### PR TITLE
Mark old environments as deprecated

### DIFF
--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,5 +1,5 @@
 environments = {
-   db123  = { environment = "dev", engine = "mysql", slack_id = "U123456" }
+#    db123  = { environment = "dev", engine = "mysql", slack_id = "U123456" }
 }
 
 aws_region = "us-east-1"


### PR DESCRIPTION
This PR automatically comments out the following environments older than  days:

- db123
